### PR TITLE
chore(deps): bump commons-lang3 from 3.8.1 to 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.8.1</version>
+        <version>3.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bumps commons-lang3 from 3.8.1 to 3.9.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>